### PR TITLE
luci-app-cifs-mounts: fix the URL to mounts

### DIFF
--- a/applications/luci-app-cifs-mount/luasrc/model/cbi/cifs.lua
+++ b/applications/luci-app-cifs-mount/luasrc/model/cbi/cifs.lua
@@ -26,7 +26,7 @@ name.size = 8
 
 pth = s:option(Value, "natpath", translate("Mount Path"))
 if nixio.fs.access("/etc/config/fstab") then
-        pth.titleref = luci.dispatcher.build_url("admin", "system", "fstab")
+        pth.titleref = luci.dispatcher.build_url("admin", "system", "mounts")
 end
 pth.rmempty = false
 pth.size = 10


### PR DESCRIPTION
ref: https://github.com/klever1988/nanopi-openwrt/issues/956