### PR TITLE
luci-app-baidupcs-web: Fix UCI is incorrect in the system log

### DIFF
--- a/applications/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
+++ b/applications/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
@@ -3,13 +3,13 @@
 START=90
 STOP=10
 
-enabled="$(uci get baidupcs-web.config.enabled)"
-port="$(uci get baidupcs-web.config.port)"
-download_dir="$(uci get baidupcs-web.config.download_dir)"
-max_download_rate="$(uci get baidupcs-web.config.max_download_rate || echo '0')"
-max_upload_rate="$(uci get baidupcs-web.config.max_upload_rate || echo '0')"
-max_download_load="$(uci get baidupcs-web.config.max_download_load || echo '1')"
-max_parallel="$(uci get baidupcs-web.config.max_parallel || echo '8')"
+enabled="$(uci -q get baidupcs-web.config.enabled)"
+port="$(uci -q get baidupcs-web.config.port)"
+download_dir="$(uci -q get baidupcs-web.config.download_dir)"
+max_download_rate="$(uci -q get baidupcs-web.config.max_download_rate || echo '0')"
+max_upload_rate="$(uci -q get baidupcs-web.config.max_upload_rate || echo '0')"
+max_download_load="$(uci -q get baidupcs-web.config.max_download_load || echo '1')"
+max_parallel="$(uci -q get baidupcs-web.config.max_parallel || echo '8')"
 
 start() {
 	stop


### PR DESCRIPTION
daemon.notice procd: /etc/rc.d/S90baidupcs-web: uci: Entry not found