### PR TITLE
luci-app-turboacc: Optimized the dns cache stop action

### DIFF
--- a/applications/luci-app-turboacc/root/etc/init.d/turboacc
+++ b/applications/luci-app-turboacc/root/etc/init.d/turboacc
@@ -9,6 +9,8 @@ extra_command "check_status" "Check running status of utils"
 
 restart_utils="true"
 
+PS="/bin/busybox ps"
+
 inital_conf(){
 	config_load "turboacc"
 	config_get "sw_flow" "config" "sw_flow" "0"
@@ -202,8 +204,9 @@ start_dnsproxy() {
 }
 
 stop_dnscache() {
-	killall -9 "dnscache"
-	kill -9 $(ps | grep dnscache-while.sh | grep -v "grep" | awk '{print $1}')
+	$PS -w | grep dnscache | grep -v "grep" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+	$PS -w | grep dnscache-while.sh | grep -v "grep" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+	killall -q -9 dnscache
 	rm -rf "/var/dnscache" "/var/run/dnscache"
 	echo "Stop DNS Caching"
 }


### PR DESCRIPTION
The actual script dnscache-while.sh is still in the process after the DNS cache stops. This optimization completely stops the script and the DNS cache process