### PR TITLE
smartdns: i18n-zh-cn add rr-ttl-reply-max

### DIFF
--- a/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
+++ b/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
@@ -217,6 +217,9 @@ msgstr "所有域名的最大 TTL 值。"
 msgid "Minimum TTL for all domain result."
 msgstr "所有域名的最小 TTL 值。"
 
+msgid "Maximum Reply TTL for all domain result."
+msgstr "设置返回给客户端的TTL最大值"
+
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
 msgid "NOT RUNNING"
 msgstr "未运行"


### PR DESCRIPTION
增加 rr-ttl-reply-max 对应的 翻译，否则 中文luci 会出现翻译不完整