### PR TITLE
luci-app-gowebdav: download reg file via javascript

### DIFF
--- a/applications/luci-app-gowebdav/luasrc/model/cbi/gowebdav.lua
+++ b/applications/luci-app-gowebdav/luasrc/model/cbi/gowebdav.lua
@@ -54,7 +54,8 @@ o = s:option(Value, "cert_key", translate("Path to Certificate Key"))
 o.datatype = "file"
 o:depends("use_https", 1)
 
-o = s:option(DummyValue, "opennewwindow", translate("<input type=\"button\" class=\"cbi-button cbi-button-apply\" value=\"Download Reg File\" onclick=\"window.open('https://raw.githubusercontent.com/1715173329/gowebdav/master/allow_http.reg')\" />"))
+o = s:option(Button, "download_reg", translate("Download Reg File"))
+o.template = "gowebdav/download_reg"
 o.description = translate("Windows doesn't allow HTTP auth by default, you need to import this reg key to enable it (Reboot needed).")
 
 return m

--- a/applications/luci-app-gowebdav/luasrc/view/gowebdav/download_reg.htm
+++ b/applications/luci-app-gowebdav/luasrc/view/gowebdav/download_reg.htm
@@ -1,0 +1,15 @@
+<%+cbi/valueheader%>
+<script type="text/javascript">//<![CDATA[
+	function download(filename, reg) {
+		var element = document.createElement('a');
+		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(reg));
+		element.setAttribute('download', filename);
+		element.style.display = 'none';
+		document.body.appendChild(element);
+		element.click();
+		document.body.removeChild(element);
+	};
+//]]>
+</script>
+<input type="button" class="btn cbi-button cbi-button-reload" value="<%:Click Download%>" onclick='download("allow_http.reg","Windows Registry Editor Version 5.00\r\n\r\n[HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WebClient\\Parameters]\r\n\"BasicAuthLevel\"=dword:00000002\r\n\"FileSizeLimitInBytes\"=dword:ffffffff")' />
+<%+cbi/valuefooter%>

--- a/applications/luci-app-gowebdav/po/zh_Hans/gowebdav.po
+++ b/applications/luci-app-gowebdav/po/zh_Hans/gowebdav.po
@@ -25,8 +25,11 @@ msgstr "开放目录"
 msgid "Read-Only Mode"
 msgstr "只读模式"
 
-msgid "<input type=\"button\" class=\"cbi-button cbi-button-apply\" value=\"Download Reg File\" onclick=\"window.open('https://raw.githubusercontent.com/1715173329/gowebdav/master/allow_http.reg')\" />"
-msgstr "<input type=\"button\" class=\"cbi-button cbi-button-apply\" value=\"下载注册表文件\" onclick=\"window.open('https://raw.githubusercontent.com/1715173329/gowebdav/master/allow_http.reg')\" />"
+msgid "Download Reg File"
+msgstr "下载注册表文件"
+
+msgid "Click Download"
+msgstr "点击下载"
 
 msgid "Windows doesn't allow HTTP auth by default, you need to import this reg key to enable it (Reboot needed)."
 msgstr "Windows 系统默认不允许 HTTP 鉴权，您需要手动导入注册表文件以开启此功能（需重启）。"


### PR DESCRIPTION
打开 https://raw.githubusercontent.com/1715173329/gowebdav/master/allow_http.reg  默认情况下会被浏览器当txt文本方式打开，需要手动去保存文本，且保存下来还要删掉txt 后缀，过于麻烦。

通过js生成文本并以 `.reg` 后缀下载会比较方便直接

![1](https://user-images.githubusercontent.com/16485166/186764804-b19b7da8-7650-4c3b-9e9c-908adf321b8d.png)
