### PR TITLE
luci-proto-cni: rename depends

### DIFF
--- a/protocols/luci-proto-cni/Makefile
+++ b/protocols/luci-proto-cni/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for CNI protocol
-LUCI_DEPENDS:=+cni-protocol
+LUCI_DEPENDS:=+external-protocol
 
 include ../../luci.mk
 


### PR DESCRIPTION
since the package cni-protocol is now renamed/replaced by this [commit](https://github.com/immortalwrt/packages/commit/a0d7e404949170ee6f6307b64c8b14a6488f14d4)

update luci depends to follow the above change