### PR TITLE
luci-app-passwall: disable ssr by default

### DIFF
--- a/applications/luci-app-passwall/Makefile
+++ b/applications/luci-app-passwall/Makefile
@@ -94,7 +94,7 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client
 	bool "Include ShadowsocksR Libev Client"
-	default y
+	default n
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
 	bool "Include ShadowsocksR Libev Server"


### PR DESCRIPTION
https://github.com/shadowsocksrr/shadowsocksr-libev is stall for about 5 years, and there is no reason to keep it "y" by default.

Anyone who desperately need SSR should either:
-  keep/stay with the old version;  OR
- figure out a way to update SSR by themselves.