### PR TITLE
Fix realtime graphs - connections is blank on lxc

### DIFF
--- a/modules/luci-base/ucode/sys.uc
+++ b/modules/luci-base/ucode/sys.uc
@@ -44,7 +44,12 @@ export function conntrack_list(callback) {
 		etcpr.close();
 	}
 
-	const nfct = open('/proc/net/nf_conntrack', 'r');
+	let nfct;
+	const s = stat(`/proc/net/nf_conntrack`);
+	if (s?.type != 'file')
+		nfct = popen('/usr/sbin/conntrack -L -o extended 2>/dev/null && /usr/sbin/conntrack -L -f ipv6 -o extended 2>/dev/null');
+	else
+		nfct = open('/proc/net/nf_conntrack', 'r');
 	let connt;
 
 	if (nfct) {

--- a/modules/luci-mod-status/src/luci-bwc.c
+++ b/modules/luci-mod-status/src/luci-bwc.c
@@ -54,6 +54,7 @@
 #define LD_SCAN_PATTERN \
 	"%f %f %f"
 
+#define CONNTRACK_PATH "/usr/sbin/conntrack"
 
 struct file_map {
 	int fd;
@@ -535,7 +536,17 @@ static int run_daemon(void)
 			closedir(dir);
 		}
 
-		if ((info = fopen(ipc, "r")) != NULL)
+		if (!stat(ipc, &s))
+		{
+			info = fopen(ipc, "r");
+		}
+		else if (!stat(CONNTRACK_PATH, &s))
+		{
+			info = popen(CONNTRACK_PATH" -L -o extended 2>/dev/null && "
+						 CONNTRACK_PATH" -L -f ipv6 -o extended 2>/dev/null", "r");
+		}
+
+		if (info != NULL)
 		{
 			udp   = 0;
 			tcp   = 0;


### PR DESCRIPTION
On new kernel Debian and Ubuntu system is lack of /proc/net/nf_conntrack, if run OpenWrt on LXC with these kernels (e.g. PVE), Realtime Graphs - Connections is blank
Fix is use conntrack-tools instead if /proc/net/nf_conntrack not exist