### PR TITLE
luci-app-cifs-mount: fix CIFS mount from Synology

### DIFF
--- a/applications/luci-app-cifs-mount/Makefile
+++ b/applications/luci-app-cifs-mount/Makefile
@@ -12,7 +12,7 @@ LUCI_PKGARCH:=all
 
 PKG_NAME:=luci-app-cifs-mount
 PKG_VERSION:=1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 include ../../luci.mk
 

--- a/applications/luci-app-cifs-mount/root/etc/init.d/cifs
+++ b/applications/luci-app-cifs-mount/root/etc/init.d/cifs
@@ -42,8 +42,8 @@ mount_natshare() {
 	config_get smbver $1 smbver
 	
 	mkdir -p $natpath && chmod 777 $natpath
-	#echo "mount -t cifs -o vers=$smbver,user=$users,password=$pwd,iocharset=$iocharset,$agm //$server/$name $natpath"
-	mount -t cifs -o vers=$smbver,user=$users,password=$pwd,iocharset=$iocharset,$agm //$server/$name $natpath
+	#echo "mount -t cifs -o vers=$smbver,user=$users,username=$users,password=$pwd,iocharset=$iocharset,$agm //$server/$name $natpath"
+	mount -t cifs -o vers=$smbver,user=$users,username=$users,password=$pwd,iocharset=$iocharset,$agm //$server/$name $natpath
 }
 
 start() {


### PR DESCRIPTION
![屏幕截图 2024-12-17 220120](https://github.com/user-attachments/assets/06ce9726-f3d2-4f5c-9612-153f1a0db177)
Synology not following [mount.cifs](https://linux.die.net/man/8/mount.cifs) standard... So we need pass multiple args for compatibility