### PR TITLE
luci-app-zerotier: fix generate nftables rules when there is more than one route

### DIFF
--- a/applications/luci-app-zerotier/root/etc/zerotier.start
+++ b/applications/luci-app-zerotier/root/etc/zerotier.start
@@ -28,7 +28,7 @@ nat_enable="$(uci get zerotier.sample_config.nat)"
 		echo "iifname $i counter accept comment \"!fw4: Zerotier allow inbound forward $i\"" >> "$nft_incdir/forward/zerotier.nft"
 		echo "oifname $i counter accept comment \"!fw4: Zerotier allow outbound forward $i\"" >> "$nft_incdir/forward/zerotier.nft"
 		echo "oifname $i counter masquerade comment \"!fw4: Zerotier $i outbound postrouting masq\"" >> "$nft_incdir/srcnat/zerotier.nft"
-		[ -z "$ip_segment" ] || echo "ip saddr $ip_segment counter masquerade comment \"!fw4: Zerotier $ip_segment postrouting masq\"" >> "$nft_incdir/srcnat/zerotier.nft"
+		[ -z "$ip_segment" ] || echo "$ip_segment" | while IFS= read -r line ; do echo "ip saddr $line counter masquerade comment \"!fw4: Zerotier $line postrouting masq\"" >> "$nft_incdir/srcnat/zerotier.nft"; done
 	done
 	echo "zt interface rules added!" > "/tmp/zero.log"
 	uci -q set firewall.@defaults[0].auto_includes="1"


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile (not applicable)
- [x] Tested on: (filogic, SNAPSHOT) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Closes: immortalwrt/luci#504
- [x] Description: 


according to #504 , the .nft file will broke if the $ip_segment is a multi-line var. 

therefore, handle this scenario with `while ....read -r`.

I've tested in a running immortalwrt shell, that this can handle both a single-line 
and multi-line $ip_segement,  but feel free to comment/try.

<img width="1539" alt="image" src="https://github.com/user-attachments/assets/216b57d5-bfed-4501-9e87-82ed7ef4591a" />

P.S. it can also be done via `xargs -I {}` but I think the busybox in immortalwrt/openwrt 
does not have `xargs -I` enabled by default.