### PR TITLE
luci-app-ipsec-vpnd: Fix LuCI status check to use actual IPsec service state

### DIFF
--- a/applications/luci-app-ipsec-vpnd/htdocs/luci-static/resources/view/ipsec-vpnd.js
+++ b/applications/luci-app-ipsec-vpnd/htdocs/luci-static/resources/view/ipsec-vpnd.js
@@ -18,10 +18,10 @@ const callServiceList = rpc.declare({
 });
 
 function getServiceStatus() {
-	return L.resolveDefault(callServiceList('ipsec-vpnd'), {}).then(function(res) {
+	return L.resolveDefault(callServiceList('ipsec'), {}).then(function(res) {
 		let isRunning = false;
 		try {
-			isRunning = res['ipsec-vpnd']['instances']['instance1']['running'];
+			isRunning = res['ipsec']['instances']['instance1']['running'];
 		} catch (e) { }
 		return isRunning;
 	});


### PR DESCRIPTION
I found that the IPsec service is actually running and connectable, but it shows as "not running" on the LuCI interface. After comparing with other [(Lean version) code](https://github.com/coolsnowwolf/luci/blob/master/applications/luci-app-ipsec-vpnd/luasrc/controller/ipsec-server.lua#L15), I discovered that the actual status of the IPsec service should be used as the basis for judgment.

我发现 IPsec 服务实际已正常运行并可连接，但在 LuCI 界面上却显示为“未运行”。对比其他[（Lean 版）的代码](https://github.com/coolsnowwolf/luci/blob/master/applications/luci-app-ipsec-vpnd/luasrc/controller/ipsec-server.lua#L15)后，发现应该以 IPsec 服务的实际状态作为判断依据。