### PR TITLE
luci-app-ipsec-vpnd: disable default ipsec service on start

### DIFF
--- a/applications/luci-app-ipsec-vpnd/root/etc/init.d/ipsec-vpnd
+++ b/applications/luci-app-ipsec-vpnd/root/etc/init.d/ipsec-vpnd
@@ -366,6 +366,11 @@ service_triggers() {
 }
 
 start_service() {
+    if /etc/init.d/ipsec enabled 2>/dev/null; then
+        /etc/init.d/ipsec stop
+        /etc/init.d/ipsec disable
+    fi
+
 	config_load ipsec-vpnd
 
 	local vt_enabled


### PR DESCRIPTION
This patch updates the init script to stop and disable the default ipsec
service before starting ipsec-vpnd. This avoids conflicts and ensures only
ipsec-vpnd is running.
