### PR TITLE
Fix the closure of getOdhcp6cStats

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -679,6 +679,7 @@ const methods = {
 			}
 
 			return { result: dev_stats };
+		}
 	},
 
 	getCPUBench: {


### PR DESCRIPTION
RPCError
RPC call to luci/getFeatures failed with error -32000: Object not found
  at ClassConstructor.handleCallReply (http://immortalwrt.lan/luci-static/resources/rpc.js?v=25.276.45481~fa1490a:11:3 )

