### PR TITLE
luci-app-udpxy: add interface hot-reload and optimize zh_Hans i18n

### DIFF
--- a/applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js
+++ b/applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js
@@ -202,11 +202,11 @@ return view.extend({
 		o = s.option(form.Value, 'buffer_size', _('Ingress buffer size'), _('Unit: bytes, Kb, Mb; Max 2097152 bytes'));
 		o.placeholder = '4Kb';
 
-		o = s.option(form.Value, 'buffer_messages', _('Buffer message amount'), _('-1 is all.'));
+		o = s.option(form.Value, 'buffer_messages', _('Buffer message amount'), _('-1 is all'));
 		o.datatype = 'or(-1, and(min(1),uinteger))';
 		o.placeholder = '1';
 
-		o = s.option(form.Value, 'buffer_time', _('Buffer time limit'), _('-1 is unlimited.'));
+		o = s.option(form.Value, 'buffer_time', _('Buffer time limit'), _('-1 is unlimited'));
 		o.datatype = 'or(-1, and(min(1),uinteger))';
 		o.placeholder = '1';
 
@@ -214,7 +214,7 @@ return view.extend({
 		o.datatype = 'or(and(max(-1),uinteger), and(min(1),uinteger))';
 		o.placeholder = '0';
 
-		o = s.option(form.Value, 'mcsub_renew', _('Renew multicast subscription periodicity'), _('Unit: seconds; 0 is skip.'));
+		o = s.option(form.Value, 'mcsub_renew', _('Renew multicast subscription periodicity'), _('Unit: seconds; 0 is skip'));
 		o.datatype = 'or(0, range(30, 64000))';
 		o.placeholder = '0';
 

--- a/applications/luci-app-udpxy/po/ar/udpxy.po
+++ b/applications/luci-app-udpxy/po/ar/udpxy.po
@@ -12,11 +12,11 @@ msgstr ""
 "X-Generator: Weblate 5.7-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -99,7 +99,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/az/udpxy.po
+++ b/applications/luci-app-udpxy/po/az/udpxy.po
@@ -8,11 +8,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -95,7 +95,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/be/udpxy.po
+++ b/applications/luci-app-udpxy/po/be/udpxy.po
@@ -12,11 +12,11 @@ msgstr ""
 "X-Generator: Weblate 5.17.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -99,7 +99,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/bg/udpxy.po
+++ b/applications/luci-app-udpxy/po/bg/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.17-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 означава всички."
+msgid "-1 is all"
+msgstr "-1 означава всички"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 означава неограничено."
+msgid "-1 is unlimited"
+msgstr "-1 означава неограничено"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/bn_BD/udpxy.po
+++ b/applications/luci-app-udpxy/po/bn_BD/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 4.9-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/ca/udpxy.po
+++ b/applications/luci-app-udpxy/po/ca/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 3.10.1\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/cs/udpxy.po
+++ b/applications/luci-app-udpxy/po/cs/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.17-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 znamená vše."
+msgid "-1 is all"
+msgstr "-1 znamená vše"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 znamená neomezeno."
+msgid "-1 is unlimited"
+msgstr "-1 znamená neomezeno"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Jednotka:: bajty, Kb, Mb – nejvýše 2097152 bajtů"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Jednotka: sekundy; 0 znamená přeskočit."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Jednotka: sekundy; 0 znamená přeskočit"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/da/udpxy.po
+++ b/applications/luci-app-udpxy/po/da/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.4-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/de/udpxy.po
+++ b/applications/luci-app-udpxy/po/de/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.13\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 ist alles."
+msgid "-1 is all"
+msgstr "-1 ist alles"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 ist unbegrenzt."
+msgid "-1 is unlimited"
+msgstr "-1 ist unbegrenzt"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Einheit: Bytes, Kb, Mb; Max. 2097152 Bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Einheit: Sekunden; 0 ist überspringen."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Einheit: Sekunden; 0 ist überspringen"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/el/udpxy.po
+++ b/applications/luci-app-udpxy/po/el/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 4.5-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/es/udpxy.po
+++ b/applications/luci-app-udpxy/po/es/udpxy.po
@@ -14,12 +14,12 @@ msgstr ""
 "X-Generator: Weblate 5.17-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 es todo."
+msgid "-1 is all"
+msgstr "-1 es todo"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 es ilimitado."
+msgid "-1 is unlimited"
+msgstr "-1 es ilimitado"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -101,8 +101,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Unidad: bytes, Kb, Mb; Máx. 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Unidad: segundos; 0 es omitir."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Unidad: segundos; 0 es omitir"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/fi/udpxy.po
+++ b/applications/luci-app-udpxy/po/fi/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.12-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 on kaikki."
+msgid "-1 is all"
+msgstr "-1 on kaikki"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 on rajoittamaton."
+msgid "-1 is unlimited"
+msgstr "-1 on rajoittamaton"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Yksiköt: tavu, kt, Mt; enintään 2097152 tavua"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Yksikkö: sekunnit; \"0\" tarkoittaa ohitusta."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Yksikkö: sekunnit; \"0\" tarkoittaa ohitusta"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/fr/udpxy.po
+++ b/applications/luci-app-udpxy/po/fr/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.15-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 pour tous."
+msgid "-1 is all"
+msgstr "-1 pour tous"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 est illimité."
+msgid "-1 is unlimited"
+msgstr "-1 est illimité"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Unité : bytes, Kb, Mb ; Max 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Unité : secondes ; 0 pour ignorer."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Unité : secondes ; 0 pour ignorer"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/ga/udpxy.po
+++ b/applications/luci-app-udpxy/po/ga/udpxy.po
@@ -12,12 +12,12 @@ msgstr ""
 "X-Generator: Weblate 5.12-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 Is léir."
+msgid "-1 is all"
+msgstr "-1 Is léir"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "Tá -1 gan teorainn."
+msgid "-1 is unlimited"
+msgstr "Tá -1 gan teorainn"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -99,8 +99,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Aonad: bearta, Kb, Mb; 2097152 beart ar a mhéad"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Aonad: soicind; Tá 0 skip."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Aonad: soicind; Tá 0 skip"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/gl/udpxy.po
+++ b/applications/luci-app-udpxy/po/gl/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.3-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/he/udpxy.po
+++ b/applications/luci-app-udpxy/po/he/udpxy.po
@@ -12,11 +12,11 @@ msgstr ""
 "X-Generator: Weblate 5.0.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -99,7 +99,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/hi/udpxy.po
+++ b/applications/luci-app-udpxy/po/hi/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.7-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/hu/udpxy.po
+++ b/applications/luci-app-udpxy/po/hu/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.15.2\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/it/udpxy.po
+++ b/applications/luci-app-udpxy/po/it/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.16-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 è tutto."
+msgid "-1 is all"
+msgstr "-1 è tutto"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 è illimitato."
+msgid "-1 is unlimited"
+msgstr "-1 è illimitato"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Unità: secondi; 0 salta."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Unità: secondi; 0 salta"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/ja/udpxy.po
+++ b/applications/luci-app-udpxy/po/ja/udpxy.po
@@ -12,11 +12,11 @@ msgstr ""
 "X-Generator: Weblate 5.15-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -99,7 +99,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/ko/udpxy.po
+++ b/applications/luci-app-udpxy/po/ko/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.17.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 은 모두를 뜻함."
+msgid "-1 is all"
+msgstr "-1 은 모두를 뜻함"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/lo/udpxy.po
+++ b/applications/luci-app-udpxy/po/lo/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.17.1\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 ແມ່ນທັງໝົດ."
+msgid "-1 is all"
+msgstr "-1 ແມ່ນທັງໝົດ"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 ແມ່ນບໍ່ຈຳກັດ."
+msgid "-1 is unlimited"
+msgstr "-1 ແມ່ນບໍ່ຈຳກັດ"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "ຫົວໜ່ວຍ: bytes, Kb, Mb; ສູງສຸດ 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "ຫົວໜ່ວຍ: ວິນາທີ; 0 ແມ່ນຂ້າມ."
+msgid "Unit: seconds; 0 is skip"
+msgstr "ຫົວໜ່ວຍ: ວິນາທີ; 0 ແມ່ນຂ້າມ"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/lt/udpxy.po
+++ b/applications/luci-app-udpxy/po/lt/udpxy.po
@@ -14,12 +14,12 @@ msgstr ""
 "X-Generator: Weblate 5.17.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 yra visi."
+msgid "-1 is all"
+msgstr "-1 yra visi"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 yra neribotas."
+msgid "-1 is unlimited"
+msgstr "-1 yra neribotas"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -102,8 +102,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Vienetas: baitai, Kb, Mb; Maks. 2097152-u baitai"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Vienetas: sekundės; 0-is yra praleisti."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Vienetas: sekundės; 0-is yra praleisti"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/mr/udpxy.po
+++ b/applications/luci-app-udpxy/po/mr/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 3.11-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/ms/udpxy.po
+++ b/applications/luci-app-udpxy/po/ms/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.4-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/nb_NO/udpxy.po
+++ b/applications/luci-app-udpxy/po/nb_NO/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.4-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/nl/udpxy.po
+++ b/applications/luci-app-udpxy/po/nl/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.15.1\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 voor alles."
+msgid "-1 is all"
+msgstr "-1 voor alles"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 is ongelimiteerd."
+msgid "-1 is unlimited"
+msgstr "-1 is ongelimiteerd"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/pl/udpxy.po
+++ b/applications/luci-app-udpxy/po/pl/udpxy.po
@@ -12,12 +12,12 @@ msgstr ""
 "X-Generator: Weblate 5.8-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 oznacza wszystko."
+msgid "-1 is all"
+msgstr "-1 oznacza wszystko"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 oznacza nieograniczenie."
+msgid "-1 is unlimited"
+msgstr "-1 oznacza nieograniczenie"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -99,8 +99,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Jednostka: bajty, Kb, Mb; maksymalnie 2097152 bajty"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Jednostka: sekundy; 0 oznacza pominięcie."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Jednostka: sekundy; 0 oznacza pominięcie"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/pt/udpxy.po
+++ b/applications/luci-app-udpxy/po/pt/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.13\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 é todos."
+msgid "-1 is all"
+msgstr "-1 é todos"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 é ilimitado."
+msgid "-1 is unlimited"
+msgstr "-1 é ilimitado"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Unidade: bytes, Kb, Mb; Max 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Unidade: segundos; 0 é pular."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Unidade: segundos; 0 é pular"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/pt_BR/udpxy.po
+++ b/applications/luci-app-udpxy/po/pt_BR/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 2026.6.dev0\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 é tudo."
+msgid "-1 is all"
+msgstr "-1 é tudo"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 é ilimitado."
+msgid "-1 is unlimited"
+msgstr "-1 é ilimitado"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/ro/udpxy.po
+++ b/applications/luci-app-udpxy/po/ro/udpxy.po
@@ -12,12 +12,12 @@ msgstr ""
 "X-Generator: Weblate 5.15-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 este tot."
+msgid "-1 is all"
+msgstr "-1 este tot"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 este nelimitat."
+msgid "-1 is unlimited"
+msgstr "-1 este nelimitat"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -99,7 +99,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/ru/udpxy.po
+++ b/applications/luci-app-udpxy/po/ru/udpxy.po
@@ -13,12 +13,12 @@ msgstr ""
 "X-Generator: Weblate 5.17.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 - это все."
+msgid "-1 is all"
+msgstr "-1 - это все"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 - неограничено."
+msgid "-1 is unlimited"
+msgstr "-1 - неограничено"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -100,8 +100,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Единицы измерения: bytes, Kb, Mb; Максимально 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Единица измерения: секунды; 0 - пропуск."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Единица измерения: секунды; 0 - пропуск"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/sk/udpxy.po
+++ b/applications/luci-app-udpxy/po/sk/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/sv/udpxy.po
+++ b/applications/luci-app-udpxy/po/sv/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.16\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 är allt."
+msgid "-1 is all"
+msgstr "-1 är allt"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 är obegränsat."
+msgid "-1 is unlimited"
+msgstr "-1 är obegränsat"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Enhet: bytes, Kb, Mb; Maximalt 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Enhet: sekunder; 0 är hoppa över."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Enhet: sekunder; 0 är hoppa över"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/ta/udpxy.po
+++ b/applications/luci-app-udpxy/po/ta/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.12-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 எல்லாம்."
+msgid "-1 is all"
+msgstr "-1 எல்லாம்"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 வரம்பற்றது."
+msgid "-1 is unlimited"
+msgstr "-1 வரம்பற்றது"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "அலகு: பைட்டுகள், கே.பி., எம்பி; அதிகபட்சம் 2097152 பைட்டுகள்"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "அலகு: விநாடிகள்; 0 ச்கிப்."
+msgid "Unit: seconds; 0 is skip"
+msgstr "அலகு: விநாடிகள்; 0 ச்கிப்"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/templates/udpxy.pot
+++ b/applications/luci-app-udpxy/po/templates/udpxy.pot
@@ -2,11 +2,11 @@ msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -89,7 +89,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/tr/udpxy.po
+++ b/applications/luci-app-udpxy/po/tr/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.14-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 tümü."
+msgid "-1 is all"
+msgstr "-1 tümü"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 sınırsız."
+msgid "-1 is unlimited"
+msgstr "-1 sınırsız"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Birim: bayt, Kb, Mb; En fazla 2097152 bayt"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Birim: saniye; 0 atlama anlamına gelir."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Birim: saniye; 0 atlama anlamına gelir"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/uk/udpxy.po
+++ b/applications/luci-app-udpxy/po/uk/udpxy.po
@@ -12,12 +12,12 @@ msgstr ""
 "X-Generator: Weblate 2026.5.dev0\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 — все."
+msgid "-1 is all"
+msgstr "-1 — все"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 — без обмежень."
+msgid "-1 is unlimited"
+msgstr "-1 — без обмежень"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -99,8 +99,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Одиниця виміру: байти, КБ, МБ; макс. 2 097 152 байтів"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Одиниця виміру: секунди; 0 — пропустити."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Одиниця виміру: секунди; 0 — пропустити"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/vi/udpxy.po
+++ b/applications/luci-app-udpxy/po/vi/udpxy.po
@@ -11,11 +11,11 @@ msgstr ""
 "X-Generator: Weblate 5.17.1-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
+msgid "-1 is all"
 msgstr "-1 Tất cả."
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
+msgid "-1 is unlimited"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
@@ -98,7 +98,7 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
+msgid "Unit: seconds; 0 is skip"
 msgstr ""
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170

--- a/applications/luci-app-udpxy/po/yua/udpxy.po
+++ b/applications/luci-app-udpxy/po/yua/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.8-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 es todo."
+msgid "-1 is all"
+msgstr "-1 es todo"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 es ilimitado."
+msgid "-1 is unlimited"
+msgstr "-1 es ilimitado"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -98,8 +98,8 @@ msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
 msgstr "Unidad: bytes, Kb, Mb; Máx 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "Unidad: segundos; 0 es omitir."
+msgid "Unit: seconds; 0 is skip"
+msgstr "Unidad: segundos; 0 es omitir"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/po/zh_Hans/udpxy.po
+++ b/applications/luci-app-udpxy/po/zh_Hans/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.17-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 即全部。"
+msgid "-1 is all"
+msgstr "-1 即全部"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 表示无限制。"
+msgid "-1 is unlimited"
+msgstr "-1 表示无限制"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -55,7 +55,7 @@ msgstr "已启用"
 
 #: applications/luci-app-udpxy/root/usr/share/rpcd/acl.d/luci-app-udpxy.json:3
 msgid "Grant UCI access for luci-app-udpxy"
-msgstr "授予UCI访问luci-app-udpxy的权限"
+msgstr "授予 UCI 访问 luci-app-udpxy 的权限"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:175
 msgid "HTTP Listen interface"
@@ -95,11 +95,11 @@ msgstr "刷新"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:202
 msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
-msgstr "单位：字节,千字节,兆字节; 最大值 2097152 字节"
+msgstr "单位：字节，千字节，兆字节；最大值 2097152 字节"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "单位：秒; 0 表示跳过。"
+msgid "Unit: seconds; 0 is skip"
+msgstr "单位：秒；0 表示跳过"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"
@@ -123,7 +123,7 @@ msgid ""
 "udpxy is an IPTV stream relay, a UDP-to-HTTP multicast traffic relay daemon "
 "which forwards multicast UDP streams to HTTP clients."
 msgstr ""
-"udpxy 是一个 IPTV 流转发工具,作为一个 UDP 到 HTTP 的组播流转发守护进程它将组"
+"udpxy 是一个 IPTV 流转发工具，作为一个 UDP 到 HTTP 的组播流转发守护进程它将组"
 "播 UDP 流转发到 HTTP 客户端。"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:39

--- a/applications/luci-app-udpxy/po/zh_Hant/udpxy.po
+++ b/applications/luci-app-udpxy/po/zh_Hant/udpxy.po
@@ -11,12 +11,12 @@ msgstr ""
 "X-Generator: Weblate 5.17-dev\n"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:205
-msgid "-1 is all."
-msgstr "-1 表示全部。"
+msgid "-1 is all"
+msgstr "-1 表示全部"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:209
-msgid "-1 is unlimited."
-msgstr "-1 表示無限制。"
+msgid "-1 is unlimited"
+msgstr "-1 表示無限制"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:115
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:119
@@ -95,11 +95,11 @@ msgstr "重新整理"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:202
 msgid "Unit: bytes, Kb, Mb; Max 2097152 bytes"
-msgstr "單位: bytes、Kb、Mb；最大 2097152 bytes"
+msgstr "單位：bytes、Kb、Mb；最大 2097152 bytes"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:217
-msgid "Unit: seconds; 0 is skip."
-msgstr "單位: 秒；0 為略過。"
+msgid "Unit: seconds; 0 is skip"
+msgstr "單位：秒；0 為略過"
 
 #: applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js:170
 msgid "Verbose logging"

--- a/applications/luci-app-udpxy/root/etc/hotplug.d/iface/99-udpxy
+++ b/applications/luci-app-udpxy/root/etc/hotplug.d/iface/99-udpxy
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+[ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
+
+check_udpxy() {
+    local cfg="$1"
+    local net ipfile newip oldip
+
+    config_get net "$cfg" source_network
+    [ "$INTERFACE" = "$net" ] || return 0
+
+    newip="$(ubus call network.interface.$net status 2>/dev/null | jsonfilter -e '@["ipv4-address"][0].address')"
+
+    ipfile="/tmp/udpxy-${net}.ip"
+
+    if [ -z "$newip" ]; then
+        rm -f "$ipfile" 2>/dev/null
+        return 0
+    fi
+
+    oldip="$(cat "$ipfile" 2>/dev/null)"
+
+    [ "$newip" = "$oldip" ] && return 0
+
+    echo "$newip" > "$ipfile"
+
+    logger -t udpxy "IP changed on $net: $oldip → $newip"
+
+    /etc/init.d/udpxy restart
+}
+
+config_load udpxy 2>/dev/null || exit 0
+config_foreach check_udpxy udpxy


### PR DESCRIPTION
## Pull request details

### Description
This PR introduces a hot-reload network monitoring feature and optimizes localization consistency:

- **Hot-Reload Script:** Added a script that dynamically monitors network interfaces based on the `source_network` configured on the page. This ensures `udpxy` automatically restarts whenever the underlying interface flaps or re-connects, keeping the multicast relay stable.
- **i18n Enhancements:** Fixed irregular formatting, full-width/half-width punctuation inconsistencies, and mixed English/Chinese punctuation issues within the Simplified Chinese (`zh_Hans`) translation files to deliver a polished and unified user interface.


### Screenshot or video of changes _(if applicable)_
### Maintainer _(preferred)_
@immortalwrt

---

## Tested on
**OpenWrt version:** ImmortalWrt 25.12.0 (Compiled from source tag)
**LuCI version:** openwrt-25.12 branch
**Web browser(s):** Chrome / Edge

### Verification Method
- **Hot-reload Script:** Validated by triggering network interface status changes via the LuCI panel and SSH, then monitoring the system log (`logread`) to confirm that `udpxy` service restarts automatically and successfully maps to the active interface.
- **i18n Optimization:** Verified directly by inspecting the LuCI web interface to ensure all Simplified Chinese strings display proper spacing, correct full-width punctuation, and visual consistency.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.