### PR TITLE
luci-app-smartdns: fix service status rendering

### DIFF
--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -52,8 +52,9 @@ function smartdnsServiceStatus() {
 	]);
 }
 
-function smartdnsRenderStatus(isRunning) {
+function smartdnsRenderStatus(res) {
 	let renderHTML = "";
+	let isRunning = res[0];
 
 	const autoSetDnsmasq = uci.get_first('smartdns', 'smartdns', 'auto_set_dnsmasq');
 	const smartdnsPort = uci.get_first('smartdns', 'smartdns', 'port');


### PR DESCRIPTION
This restores the previous status rendering behavior for luci-app-smartdns.

`smartdnsServiceStatus()` returns a Promise.all() result, so the render helper receives an array like `[false]`. The old implementation accepted `res` and derived the actual boolean with `res[0]` inside `smartdnsRenderStatus()`.

During the JS linting / ES6 treatment change, the parameter was changed to `isRunning`, while the call site still passed the whole `res` array. Since arrays are truthy in JavaScript, `[false]` rendered as running.

Restore the historical/upstream style:

- `smartdnsRenderStatus(res)` accepts the Promise.all() result
- `let isRunning = res[0]` extracts the actual service state

References pymumu/smartdns#2369.