### PR TITLE
luci-app-ddns-go: fix URL construction on non-standard ports

### DIFF
--- a/applications/luci-app-ddns-go/htdocs/luci-static/resources/view/ddns-go.js
+++ b/applications/luci-app-ddns-go/htdocs/luci-static/resources/view/ddns-go.js
@@ -31,7 +31,7 @@ function renderStatus(isRunning, listen_port, noweb) {
 		renderHTML = spanTemp.format('green', _('DDNS-Go'), _('RUNNING'));
 		if (noweb !== '1')
 			renderHTML+= String.format('&#160;<a class="btn cbi-button" href="%s:%s" target="_blank" rel="noreferrer noopener">%s</a>',
-				window.location.origin, listen_port, _('Open Web Interface'));
+				window.location.protocol + '//' + window.location.hostname, listen_port, _('Open Web Interface'));
 	} else {
 		renderHTML = spanTemp.format('red', _('DDNS-Go'), _('NOT RUNNING'));
 	}


### PR DESCRIPTION
When LuCI is accessed via a non-standard port (e.g. :8080), window.location.origin includes the port in the returned value. Concatenating the ddns-go listen port afterwards produces an invalid URL with two port segments (e.g. "http://host:8080:9876").

Fix by using window.location.protocol + "//" + window.location.hostname instead of window.location.origin, which excludes the port from the host portion.