### PR TITLE
luci-app-fancontrol: add PWM fan controller interface

### DIFF
--- a/applications/luci-app-fancontrol/Makefile
+++ b/applications/luci-app-fancontrol/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2026 JiaY-shi
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for the generic PWM fan controller
+LUCI_DEPENDS:=+luci-base +fancontrol
+
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=JiaY-shi <shi05275@163.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.css
+++ b/applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.css
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2026 JiaY-shi
+ */
+
+.fancontrol-runtime {
+	margin-bottom: 1.5rem;
+}
+
+.fancontrol-status {
+	width: 100%;
+	max-width: 1200px;
+	overflow: hidden;
+	border: 1px solid rgba(127, 127, 127, .28);
+	border-radius: 6px;
+}
+
+.fancontrol-status-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 0;
+	padding: .4rem .7rem;
+	background: rgba(127, 127, 127, .08);
+	border-bottom: 1px solid rgba(127, 127, 127, .22);
+}
+
+.fancontrol-status-title {
+	font-size: .88rem;
+	font-weight: 600;
+}
+
+.fancontrol-metrics {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.fancontrol-metric {
+	min-width: 0;
+	min-height: 0;
+	padding: .55rem .7rem;
+	border-right: 1px solid rgba(127, 127, 127, .2);
+}
+
+.fancontrol-metric:last-child {
+	border-right: 0;
+}
+
+.fancontrol-metric-label,
+.fancontrol-detail-label {
+	display: block;
+	color: var(--text-color-medium, inherit);
+	font-size: .72rem;
+}
+
+.fancontrol-metric-reading {
+	display: flex;
+	align-items: baseline;
+	gap: .3rem;
+	min-height: 0;
+	margin-top: .12rem;
+	white-space: nowrap;
+}
+
+.fancontrol-metric-value {
+	font-size: 1.18rem;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.fancontrol-metric-unit {
+	overflow: hidden;
+	color: var(--text-color-medium, inherit);
+	font-size: .72rem;
+	text-overflow: ellipsis;
+}
+
+.fancontrol-chart-wrap {
+	height: 72px;
+	margin-top: .4rem;
+}
+
+.fancontrol-chart {
+	display: block;
+	width: 100%;
+	height: 100%;
+	color: var(--text-color-medium, #666);
+	background: rgba(127, 127, 127, .025);
+	border: 1px solid rgba(127, 127, 127, .24);
+}
+
+.fancontrol-chart-temperature {
+	--fancontrol-chart-line: #c74b45;
+	--fancontrol-chart-fill: rgba(199, 75, 69, .2);
+}
+
+.fancontrol-chart-pwm {
+	--fancontrol-chart-line: #1976d2;
+	--fancontrol-chart-fill: rgba(25, 118, 210, .2);
+}
+
+.fancontrol-chart-rpm {
+	--fancontrol-chart-line: #2f8a57;
+	--fancontrol-chart-fill: rgba(47, 138, 87, .2);
+}
+
+.fancontrol-details {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: .3rem 1rem;
+	padding: .42rem .7rem;
+	background: rgba(127, 127, 127, .04);
+	border-top: 1px solid rgba(127, 127, 127, .2);
+}
+
+.fancontrol-detail {
+	display: grid;
+	grid-template-columns: minmax(7rem, .34fr) minmax(0, 1fr);
+	align-items: baseline;
+	gap: .45rem;
+	min-width: 0;
+}
+
+.fancontrol-detail-value {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.fancontrol-ok {
+	color: var(--success-color-medium, #00884a);
+}
+
+@media (max-width: 700px) {
+	.fancontrol-metrics {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.fancontrol-metric:nth-child(2) {
+		border-right: 0;
+	}
+
+	.fancontrol-metric:last-child {
+		grid-column: 1 / -1;
+		border-top: 1px solid rgba(127, 127, 127, .2);
+	}
+
+	.fancontrol-details {
+		grid-template-columns: 1fr;
+	}
+
+}
+
+@media (max-width: 420px) {
+	.fancontrol-metrics {
+		grid-template-columns: 1fr;
+	}
+
+	.fancontrol-metric,
+	.fancontrol-metric:nth-child(2) {
+		border-right: 0;
+		border-top: 1px solid rgba(127, 127, 127, .2);
+	}
+
+	.fancontrol-metric:first-child {
+		border-top: 0;
+	}
+
+	.fancontrol-metric:last-child {
+		grid-column: auto;
+	}
+
+	.fancontrol-detail {
+		grid-template-columns: 1fr;
+		gap: .15rem;
+	}
+}

--- a/applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js
+++ b/applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js
@@ -1,0 +1,458 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2026 JiaY-shi
+ */
+
+'use strict';
+'require dom';
+'require form';
+'require fs';
+'require poll';
+'require rpc';
+'require uci';
+'require view';
+
+const callServiceList = rpc.declare({
+	object: 'service',
+	method: 'list',
+	params: [ 'name' ],
+	expect: { '': {} }
+});
+
+const HISTORY_WINDOW_MS = 2 * 60 * 1000;
+const TIME_GRID_INTERVAL_MS = 10 * 1000;
+const TIME_LABEL_INTERVAL_MS = 30 * 1000;
+const VALUE_GRID_DIVISIONS = 4;
+
+function serviceRunning(result) {
+	const instances = result?.fancontrol?.instances || {};
+
+	return Object.keys(instances).some(function(name) {
+		return instances[name].running === true;
+	});
+}
+
+function parseStatus(text) {
+	const status = {};
+
+	String(text || '').split(/\n/).forEach(function(line) {
+		const separator = line.indexOf('=');
+
+		if (separator > 0)
+			status[line.substring(0, separator)] = line.substring(separator + 1);
+	});
+
+	return status;
+}
+
+function validStatusNumber(value) {
+	const number = Number(value);
+
+	return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function appendHistory(history, running, status) {
+	const now = Date.now();
+	const temperature = validStatusNumber(status.temperature_mc);
+	const pwm = validStatusNumber(status.pwm);
+	const rpm = validStatusNumber(status.rpm);
+
+	history.push({
+		time: now,
+		temperature: running && temperature != null ? temperature / 1000 : null,
+		pwm: running && pwm != null ? pwm * 100 / 255 : null,
+		rpm: running ? rpm : null
+	});
+
+	while (history.length && history[0].time < now - HISTORY_WINDOW_MS)
+		history.shift();
+}
+
+function chartScale(history, key, minimumMax, step) {
+	let maximum = minimumMax;
+
+	history.forEach(function(sample) {
+		if (sample[key] != null)
+			maximum = Math.max(maximum, sample[key]);
+	});
+
+	return Math.ceil(maximum / step) * step;
+}
+
+function drawChart(canvas, history, key, options) {
+	const style = window.getComputedStyle(canvas);
+	const width = Math.max(canvas.clientWidth, 1);
+	const height = Math.max(canvas.clientHeight, 1);
+	const ratio = Math.min(window.devicePixelRatio || 1, 2);
+	const context = canvas.getContext('2d');
+	const padding = { left: 28, right: 5, top: 6, bottom: 14 };
+	const plotWidth = Math.max(width - padding.left - padding.right, 1);
+	const plotHeight = Math.max(height - padding.top - padding.bottom, 1);
+	const plotBottom = padding.top + plotHeight;
+	const now = history.length ? history[history.length - 1].time : Date.now();
+	const start = now - HISTORY_WINDOW_MS;
+	const maximum = chartScale(history, key, options.minimumMax, options.step);
+	const lineColor = style.getPropertyValue('--fancontrol-chart-line').trim() || '#1976d2';
+	const fillColor = style.getPropertyValue('--fancontrol-chart-fill').trim() || 'rgba(25, 118, 210, .2)';
+	const labelColor = style.color || '#666';
+	const gridColor = 'rgba(127, 127, 127, .2)';
+	let segment = [];
+
+	canvas.width = Math.round(width * ratio);
+	canvas.height = Math.round(height * ratio);
+	context.setTransform(ratio, 0, 0, ratio, 0, 0);
+	context.clearRect(0, 0, width, height);
+
+	context.strokeStyle = gridColor;
+	context.lineWidth = 1;
+	context.beginPath();
+	for (let elapsed = 0; elapsed <= HISTORY_WINDOW_MS; elapsed += TIME_GRID_INTERVAL_MS) {
+		const x = padding.left + plotWidth * elapsed / HISTORY_WINDOW_MS;
+
+		context.moveTo(x, padding.top);
+		context.lineTo(x, plotBottom);
+	}
+	for (let division = 0; division <= VALUE_GRID_DIVISIONS; division++) {
+		const y = padding.top + plotHeight * division / VALUE_GRID_DIVISIONS;
+
+		context.moveTo(padding.left, y);
+		context.lineTo(padding.left + plotWidth, y);
+	}
+	context.stroke();
+
+	context.fillStyle = labelColor;
+	context.font = '9px sans-serif';
+	context.textAlign = 'right';
+	context.textBaseline = 'top';
+	context.fillText(options.format(maximum), padding.left - 4, padding.top - 1);
+	context.textBaseline = 'bottom';
+	context.fillText(options.format(0), padding.left - 4, plotBottom + 1);
+	context.textBaseline = 'middle';
+	context.fillText(options.format(maximum / 2), padding.left - 4,
+		padding.top + plotHeight / 2);
+
+	context.textBaseline = 'bottom';
+	for (let elapsed = 0; elapsed <= HISTORY_WINDOW_MS; elapsed += TIME_LABEL_INTERVAL_MS) {
+		const x = padding.left + plotWidth * elapsed / HISTORY_WINDOW_MS;
+		const remaining = (HISTORY_WINDOW_MS - elapsed) / 1000;
+
+		context.textAlign = elapsed === 0 ? 'left' :
+			elapsed === HISTORY_WINDOW_MS ? 'right' : 'center';
+		context.fillText(remaining ? '-%ds'.format(remaining) : '0', x, height);
+	}
+
+	function point(sample) {
+		return {
+			x: padding.left + (sample.time - start) / HISTORY_WINDOW_MS * plotWidth,
+			y: plotBottom - sample[key] / maximum * plotHeight
+		};
+	}
+
+	function drawSegment() {
+		if (!segment.length)
+			return;
+
+		if (segment.length > 1) {
+			context.beginPath();
+			context.moveTo(segment[0].x, plotBottom);
+			segment.forEach(function(item) { context.lineTo(item.x, item.y); });
+			context.lineTo(segment[segment.length - 1].x, plotBottom);
+			context.closePath();
+			context.fillStyle = fillColor;
+			context.fill();
+
+			context.beginPath();
+			segment.forEach(function(item, index) {
+				if (index)
+					context.lineTo(item.x, item.y);
+				else
+					context.moveTo(item.x, item.y);
+			});
+			context.strokeStyle = lineColor;
+			context.lineWidth = 1.5;
+			context.lineJoin = 'round';
+			context.stroke();
+		} else {
+			context.beginPath();
+			context.arc(segment[0].x, segment[0].y, 2, 0, Math.PI * 2);
+			context.fillStyle = lineColor;
+			context.fill();
+		}
+
+		segment = [];
+	}
+
+	history.forEach(function(sample) {
+		if (sample[key] == null) {
+			drawSegment();
+			return;
+		}
+
+		segment.push(point(sample));
+	});
+	drawSegment();
+}
+
+function statusMetric(title, value, unit, chartClass) {
+	const canvas = E('canvas', {
+		'class': 'fancontrol-chart fancontrol-chart-%s'.format(chartClass),
+		'role': 'img',
+		'aria-label': title
+	});
+	const children = [
+		E('span', { 'class': 'fancontrol-metric-label' }, title),
+		E('div', { 'class': 'fancontrol-metric-reading' }, [
+			E('span', { 'class': 'fancontrol-metric-value' }, value),
+			unit ? E('span', { 'class': 'fancontrol-metric-unit' }, unit) : ''
+		]),
+		E('div', { 'class': 'fancontrol-chart-wrap' }, canvas)
+	];
+
+	return {
+		node: E('div', { 'class': 'fancontrol-metric' }, children),
+		canvas: canvas
+	};
+}
+
+function statusDetail(title, value) {
+	return E('div', { 'class': 'fancontrol-detail' }, [
+		E('span', { 'class': 'fancontrol-detail-label' }, title),
+		E('span', { 'class': 'fancontrol-detail-value' }, value)
+	]);
+}
+
+function renderStatus(node, running, status, history) {
+	const temp = Number(status.temperature_mc);
+	const pwm = Number(status.pwm);
+	const rpm = Number(status.rpm);
+	const tempValid = Number.isFinite(temp) && temp >= 0;
+	const pwmValid = Number.isFinite(pwm) && pwm >= 0;
+	const rpmValid = Number.isFinite(rpm) && rpm >= 0;
+	const pwmPercent = pwmValid ? Math.round(pwm * 100 / 255) : null;
+	const fault = status.error
+		? E('span', { 'class': 'label warning' }, status.error)
+		: E('span', { 'class': 'fancontrol-ok' }, _('None'));
+	const temperatureMetric = statusMetric(_('Temperature'),
+		tempValid ? '%.1f'.format(temp / 1000) : '-', tempValid ? '°C' : '', 'temperature');
+	const pwmMetric = statusMetric(_('PWM output'), pwmValid ? String(pwm) : '-',
+		pwmValid ? '/ 255 · %d%%'.format(pwmPercent) : '', 'pwm');
+	const rpmMetric = statusMetric(_('Fan speed'), rpmValid ? String(rpm) : '-',
+		rpmValid ? 'RPM' : '', 'rpm');
+
+	dom.content(node, E('div', { 'class': 'fancontrol-status' }, [
+		E('div', { 'class': 'fancontrol-status-head' }, [
+			E('span', { 'class': 'fancontrol-status-title' }, _('Runtime Status')),
+			E('span', { 'class': running ? 'label success' : 'label warning' },
+				running ? _('Running') : _('Stopped'))
+		]),
+		E('div', { 'class': 'fancontrol-metrics' }, [
+			temperatureMetric.node,
+			pwmMetric.node,
+			rpmMetric.node
+		]),
+		E('div', { 'class': 'fancontrol-details' }, [
+			statusDetail(_('Temperature input'), status.thermal_file || '-'),
+			statusDetail(_('PWM device'), status.fan_file || '-'),
+			statusDetail(_('Fault'), fault)
+		])
+	]));
+
+	drawChart(temperatureMetric.canvas, history, 'temperature', {
+		minimumMax: 100,
+		step: 10,
+		format: function(value) { return '%d°'.format(value); }
+	});
+	drawChart(pwmMetric.canvas, history, 'pwm', {
+		minimumMax: 100,
+		step: 100,
+		format: function(value) { return '%d%%'.format(value); }
+	});
+	drawChart(rpmMetric.canvas, history, 'rpm', {
+		minimumMax: 1000,
+		step: 500,
+		format: function(value) { return String(value); }
+	});
+}
+
+function validateAutoPath(sectionId, value) {
+	if (value === 'auto' || value?.startsWith('/'))
+		return true;
+
+	return _('Enter "auto" or an absolute sysfs path.');
+}
+
+return view.extend({
+	load() {
+		return uci.load('fancontrol');
+	},
+
+	render() {
+		let m, s, o;
+		let startTemp, fullTemp, startSpeed, maxSpeed, kickSpeed, kickMs;
+
+		m = new form.Map('fancontrol', _('Fan Control'),
+			_('Configure a continuous PWM curve based on device temperature. Automatic hardware detection is suitable for most devices.'));
+
+		s = m.section(form.TypedSection, 'fancontrol', _('Runtime Status'));
+		s.anonymous = true;
+		s.addremove = false;
+		s.render = function() {
+			const history = [];
+			const node = E('div', { 'class': 'cbi-section fancontrol-runtime' }, [
+				E('link', {
+					'rel': 'stylesheet',
+					'href': L.resource('view/fancontrol.css')
+				}),
+				E('div', { 'class': 'cbi-section-node' }, _('Collecting data...'))
+			]);
+			const statusNode = node.lastElementChild;
+
+			poll.add(function() {
+				return Promise.all([
+					L.resolveDefault(callServiceList('fancontrol'), {}),
+					L.resolveDefault(fs.read_direct('/var/run/fancontrol.status'), '')
+				]).then(function(result) {
+					const running = serviceRunning(result[0]);
+					const status = parseStatus(result[1]);
+
+					appendHistory(history, running, status);
+					renderStatus(statusNode, running, status, history);
+				});
+			}, 5);
+
+			return node;
+		};
+
+		s = m.section(form.NamedSection, 'settings', 'fancontrol', _('Settings'));
+		s.addremove = false;
+		s.tab('curve', _('Temperature Curve'),
+			_('Controls when the fan starts and how its speed rises with temperature.'));
+		s.tab('hardware', _('Hardware'),
+			_('Automatic detection works on most devices. Select explicit sysfs entries only when necessary.'));
+		s.tab('safety', _('Safety'),
+			_('Controls startup assistance and fail-safe behavior. Full-speed safety defaults are recommended.'));
+
+		o = s.taboption('curve', form.Flag, 'enabled', _('Enable'));
+		o.default = o.disabled;
+		o.rmempty = false;
+		o.description = _('Run the controller and apply this temperature curve.');
+
+		startTemp = s.taboption('curve', form.Value, 'start_temp', _('Start temperature'));
+		startTemp.default = '45';
+		startTemp.datatype = 'range(-40,200)';
+		startTemp.rmempty = false;
+		startTemp.description = _('The fan remains off below this temperature and starts at the minimum running PWM when it is reached. Unit: °C.');
+
+		fullTemp = s.taboption('curve', form.Value, 'full_speed_temp', _('Full-speed temperature'));
+		fullTemp.default = '85';
+		fullTemp.datatype = 'range(-39,250)';
+		fullTemp.rmempty = false;
+		fullTemp.description = _('PWM rises linearly and reaches the configured maximum at this temperature. Unit: °C.');
+		fullTemp.validate = function(sectionId, value) {
+			if (Number(value) <= Number(startTemp.formvalue(sectionId)))
+				return _('Full-speed temperature must be higher than start temperature.');
+			return true;
+		};
+
+		o = s.taboption('curve', form.Value, 'hysteresis', _('Stop hysteresis'));
+		o.default = '3';
+		o.datatype = 'range(0,50)';
+		o.rmempty = false;
+		o.description = _('After starting, the fan stops only after temperature falls this many degrees below the start temperature. This prevents rapid on/off cycling.');
+
+		startSpeed = s.taboption('curve', form.Value, 'start_speed', _('Minimum running PWM'));
+		startSpeed.default = '64';
+		startSpeed.datatype = 'range(1,255)';
+		startSpeed.rmempty = false;
+		startSpeed.description = _('Lowest PWM used while the fan is running. Increase it if the fan stalls or cannot maintain rotation. Range: 1–255.');
+
+		maxSpeed = s.taboption('curve', form.Value, 'max_speed', _('Maximum PWM'));
+		maxSpeed.default = '255';
+		maxSpeed.datatype = 'range(1,255)';
+		maxSpeed.rmempty = false;
+		maxSpeed.description = _('Highest PWM allowed by the curve. A value of 255 means 100% duty cycle.');
+		maxSpeed.validate = function(sectionId, value) {
+			if (Number(value) < Number(startSpeed.formvalue(sectionId)))
+				return _('Maximum PWM must not be lower than minimum running PWM.');
+			return true;
+		};
+
+		o = s.taboption('curve', form.Value, 'interval', _('Polling interval'));
+		o.default = '5';
+		o.datatype = 'range(1,300)';
+		o.rmempty = false;
+		o.description = _('How often the temperature is read and the PWM output is updated. Unit: seconds.');
+
+		o = s.taboption('hardware', form.Value, 'thermal_file', _('Temperature input'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.validate = validateAutoPath;
+		o.description = _('Use "auto" to select a CPU or SoC thermal sensor, or enter an absolute thermal zone or hwmon tempN_input path.');
+
+		o = s.taboption('hardware', form.Value, 'thermal_zone', _('Thermal zone type'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.description = _('Preferred thermal zone type when temperature input is automatic, for example cpu_top_thermal. Leave as "auto" unless several sensors are available.');
+
+		o = s.taboption('hardware', form.Value, 'fan_file', _('PWM output'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.validate = validateAutoPath;
+		o.description = _('Use "auto" to select a writable hwmon pwmN output, or enter its absolute path. cooling_device cur_state is not a PWM output.');
+
+		o = s.taboption('hardware', form.Value, 'fan_hwmon', _('Hwmon device name'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.description = _('Preferred hwmon name when PWM output is automatic. The pwmfan driver is preferred by default.');
+
+		o = s.taboption('hardware', form.Value, 'enable_file', _('PWM mode control'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.validate = validateAutoPath;
+		o.description = _('Optional pwmN_enable path used to select manual PWM mode. With "auto", the matching control is used when available.');
+
+		o = s.taboption('hardware', form.Value, 'temp_div', _('Temperature divisor'));
+		o.default = '1000';
+		o.value('1');
+		o.value('1000');
+		o.datatype = 'range(1,1000000)';
+		o.rmempty = false;
+		o.description = _('Divides the raw sensor value before control calculations. Standard Linux temperature inputs use 1000; sensors reporting whole degrees use 1.');
+
+		kickSpeed = s.taboption('safety', form.Value, 'kick_speed', _('Start kick PWM'));
+		kickSpeed.default = '255';
+		kickSpeed.datatype = 'range(0,255)';
+		kickSpeed.rmempty = false;
+		kickSpeed.description = _('Brief PWM applied when a stopped fan starts. It helps fans that cannot start reliably at low duty. Set to 0 together with a zero duration to disable.');
+
+		kickMs = s.taboption('safety', form.Value, 'kick_ms', _('Start kick duration'));
+		kickMs.default = '500';
+		kickMs.datatype = 'range(0,10000)';
+		kickMs.rmempty = false;
+		kickMs.description = _('How long the startup kick is applied. Unit: milliseconds.');
+		kickMs.validate = function(sectionId, value) {
+			if (Number(value) > 0 && Number(kickSpeed.formvalue(sectionId)) === 0)
+				return _('Start kick PWM must be non-zero when a kick duration is configured.');
+			return true;
+		};
+
+		o = s.taboption('safety', form.Value, 'fail_safe_speed', _('Sensor failure PWM'));
+		o.default = '255';
+		o.datatype = 'range(0,255)';
+		o.rmempty = false;
+		o.description = _('PWM used when the temperature sensor cannot be read. Keeping 255 is the safest choice.');
+
+		o = s.taboption('safety', form.Value, 'exit_speed', _('Service exit PWM'));
+		o.default = '255';
+		o.datatype = 'range(0,255)';
+		o.rmempty = false;
+		o.description = _('PWM written when the service stops. Keeping the fan at full speed avoids losing cooling after an unexpected exit.');
+
+		o = s.taboption('safety', form.Flag, 'debug', _('Debug logging'));
+		o.default = o.disabled;
+		o.rmempty = false;
+		o.description = _('Write temperature, PWM and RPM values to the system log at every polling interval.');
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-fancontrol/po/templates/fancontrol.pot
+++ b/applications/luci-app-fancontrol/po/templates/fancontrol.pot
@@ -1,0 +1,278 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:361
+msgid ""
+"After starting, the fan stops only after temperature falls this many degrees "
+"below the start temperature. This prevents rapid on/off cycling."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:331
+msgid ""
+"Automatic detection works on most devices. Select explicit sysfs entries "
+"only when necessary."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:426
+msgid ""
+"Brief PWM applied when a stopped fan starts. It helps fans that cannot start "
+"reliably at low duty. Set to 0 together with a zero duration to disable."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:306
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:294
+msgid ""
+"Configure a continuous PWM curve based on device temperature. Automatic "
+"hardware detection is suitable for most devices."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:333
+msgid ""
+"Controls startup assistance and fail-safe behavior. Full-speed safety "
+"defaults are recommended."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:329
+msgid "Controls when the fan starts and how its speed rises with temperature."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:451
+msgid "Debug logging"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:420
+msgid ""
+"Divides the raw sensor value before control calculations. Standard Linux "
+"temperature inputs use 1000; sensors reporting whole degrees use 1."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:335
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:281
+msgid "Enter \"auto\" or an absolute sysfs path."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:293
+#: applications/luci-app-fancontrol/root/usr/share/luci/menu.d/luci-app-fancontrol.json:3
+msgid "Fan Control"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:239
+msgid "Fan speed"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:256
+msgid "Fault"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:346
+msgid "Full-speed temperature"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:353
+msgid "Full-speed temperature must be higher than start temperature."
+msgstr ""
+
+#: applications/luci-app-fancontrol/root/usr/share/rpcd/acl.d/luci-app-fancontrol.json:3
+msgid "Grant access to Fan Control"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:330
+msgid "Hardware"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:373
+msgid "Highest PWM allowed by the curve. A value of 255 means 100% duty cycle."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:432
+msgid "How long the startup kick is applied. Unit: milliseconds."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:384
+msgid ""
+"How often the temperature is read and the PWM output is updated. Unit: "
+"seconds."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:403
+msgid "Hwmon device name"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:367
+msgid ""
+"Lowest PWM used while the fan is running. Increase it if the fan stalls or "
+"cannot maintain rotation. Range: 1–255."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:369
+msgid "Maximum PWM"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:376
+msgid "Maximum PWM must not be lower than minimum running PWM."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:363
+msgid "Minimum running PWM"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:234
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:412
+msgid ""
+"Optional pwmN_enable path used to select manual PWM mode. With \"auto\", the "
+"matching control is used when available."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:255
+msgid "PWM device"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:408
+msgid "PWM mode control"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:237
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:397
+msgid "PWM output"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:350
+msgid ""
+"PWM rises linearly and reaches the configured maximum at this temperature. "
+"Unit: °C."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:443
+msgid ""
+"PWM used when the temperature sensor cannot be read. Keeping 255 is the "
+"safest choice."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:449
+msgid ""
+"PWM written when the service stops. Keeping the fan at full speed avoids "
+"losing cooling after an unexpected exit."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:380
+msgid "Polling interval"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:406
+msgid ""
+"Preferred hwmon name when PWM output is automatic. The pwmfan driver is "
+"preferred by default."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:395
+msgid ""
+"Preferred thermal zone type when temperature input is automatic, for example "
+"cpu_top_thermal. Leave as \"auto\" unless several sensors are available."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:338
+msgid "Run the controller and apply this temperature curve."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:246
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:244
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:296
+msgid "Runtime Status"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:332
+msgid "Safety"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:439
+msgid "Sensor failure PWM"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:445
+msgid "Service exit PWM"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:326
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:422
+msgid "Start kick PWM"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:435
+msgid "Start kick PWM must be non-zero when a kick duration is configured."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:428
+msgid "Start kick duration"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:340
+msgid "Start temperature"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:357
+msgid "Stop hysteresis"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:246
+msgid "Stopped"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:235
+msgid "Temperature"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:328
+msgid "Temperature Curve"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:414
+msgid "Temperature divisor"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:254
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:386
+msgid "Temperature input"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:344
+msgid ""
+"The fan remains off below this temperature and starts at the minimum running "
+"PWM when it is reached. Unit: °C."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:392
+msgid "Thermal zone type"
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:390
+msgid ""
+"Use \"auto\" to select a CPU or SoC thermal sensor, or enter an absolute "
+"thermal zone or hwmon tempN_input path."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:401
+msgid ""
+"Use \"auto\" to select a writable hwmon pwmN output, or enter its absolute "
+"path. cooling_device cur_state is not a PWM output."
+msgstr ""
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:454
+msgid ""
+"Write temperature, PWM and RPM values to the system log at every polling "
+"interval."
+msgstr ""

--- a/applications/luci-app-fancontrol/po/zh_Hans/fancontrol.po
+++ b/applications/luci-app-fancontrol/po/zh_Hans/fancontrol.po
@@ -1,0 +1,303 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: luci-app-fancontrol 2.1.0\n"
+"PO-Revision-Date: 2026-08-24 14:34+0800\n"
+"Last-Translator: JiaY-shi <shi05275@163.com>\n"
+"Language-Team: Chinese (Simplified Han script)\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:361
+msgid ""
+"After starting, the fan stops only after temperature falls this many degrees "
+"below the start temperature. This prevents rapid on/off cycling."
+msgstr ""
+"风扇启动后，温度需要降到比启动温度低这么多度时才会停转，避免风扇频繁启停。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:331
+msgid ""
+"Automatic detection works on most devices. Select explicit sysfs entries "
+"only when necessary."
+msgstr "自动检测适用于大多数设备，仅在必要时手动指定 sysfs 项。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:426
+msgid ""
+"Brief PWM applied when a stopped fan starts. It helps fans that cannot start "
+"reliably at low duty. Set to 0 together with a zero duration to disable."
+msgstr ""
+"风扇从停止状态启动时短暂使用的 PWM，可帮助低占空比下无法可靠启动的风扇。将此"
+"项和助推时长都设为 0 可禁用。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:306
+msgid "Collecting data..."
+msgstr "正在采集数据..."
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:294
+msgid ""
+"Configure a continuous PWM curve based on device temperature. Automatic "
+"hardware detection is suitable for most devices."
+msgstr "根据设备温度配置连续 PWM 调速曲线。自动硬件检测适用于大多数设备。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:333
+msgid ""
+"Controls startup assistance and fail-safe behavior. Full-speed safety "
+"defaults are recommended."
+msgstr "控制启动助推和故障保护行为，建议保留默认的全速安全设置。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:329
+msgid "Controls when the fan starts and how its speed rises with temperature."
+msgstr "控制风扇何时启动，以及转速如何随温度升高。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:451
+msgid "Debug logging"
+msgstr "调试日志"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:420
+msgid ""
+"Divides the raw sensor value before control calculations. Standard Linux "
+"temperature inputs use 1000; sensors reporting whole degrees use 1."
+msgstr ""
+"进行控制计算前用于换算传感器原始值。标准 Linux 温度输入使用 1000，直接报告摄"
+"氏度的传感器使用 1。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:335
+msgid "Enable"
+msgstr "启用"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:281
+msgid "Enter \"auto\" or an absolute sysfs path."
+msgstr "请输入 \"auto\" 或 sysfs 绝对路径。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:293
+#: applications/luci-app-fancontrol/root/usr/share/luci/menu.d/luci-app-fancontrol.json:3
+msgid "Fan Control"
+msgstr "风扇控制"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:239
+msgid "Fan speed"
+msgstr "风扇转速"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:256
+msgid "Fault"
+msgstr "故障"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:346
+msgid "Full-speed temperature"
+msgstr "全速温度"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:353
+msgid "Full-speed temperature must be higher than start temperature."
+msgstr "全速温度必须高于启动温度。"
+
+#: applications/luci-app-fancontrol/root/usr/share/rpcd/acl.d/luci-app-fancontrol.json:3
+msgid "Grant access to Fan Control"
+msgstr "授予风扇控制访问权限"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:330
+msgid "Hardware"
+msgstr "硬件"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:373
+msgid "Highest PWM allowed by the curve. A value of 255 means 100% duty cycle."
+msgstr "温控曲线允许的最高 PWM，255 表示 100% 占空比。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:432
+msgid "How long the startup kick is applied. Unit: milliseconds."
+msgstr "启动助推持续的时间，单位为毫秒。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:384
+msgid ""
+"How often the temperature is read and the PWM output is updated. Unit: "
+"seconds."
+msgstr "读取温度并更新 PWM 输出的时间间隔，单位为秒。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:403
+msgid "Hwmon device name"
+msgstr "Hwmon 设备名称"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:367
+msgid ""
+"Lowest PWM used while the fan is running. Increase it if the fan stalls or "
+"cannot maintain rotation. Range: 1–255."
+msgstr ""
+"风扇运行时使用的最低 PWM。如果风扇停转或无法持续旋转，请提高此值。范围：1–"
+"255。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:369
+msgid "Maximum PWM"
+msgstr "最大 PWM"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:376
+msgid "Maximum PWM must not be lower than minimum running PWM."
+msgstr "最大 PWM 不得低于最低运行 PWM。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:363
+msgid "Minimum running PWM"
+msgstr "最低运行 PWM"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:234
+msgid "None"
+msgstr "无"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:412
+msgid ""
+"Optional pwmN_enable path used to select manual PWM mode. With \"auto\", the "
+"matching control is used when available."
+msgstr ""
+"用于选择手动 PWM 模式的可选 pwmN_enable 路径。设为 \"auto\" 时会自动使用匹配"
+"的控制项。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:255
+msgid "PWM device"
+msgstr "PWM 设备"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:408
+msgid "PWM mode control"
+msgstr "PWM 模式控制"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:237
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:397
+msgid "PWM output"
+msgstr "PWM 输出"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:350
+msgid ""
+"PWM rises linearly and reaches the configured maximum at this temperature. "
+"Unit: °C."
+msgstr "PWM 随温度线性升高，并在此温度达到设定的最大值，单位为 °C。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:443
+msgid ""
+"PWM used when the temperature sensor cannot be read. Keeping 255 is the "
+"safest choice."
+msgstr "温度传感器读取失败时使用的 PWM。保持 255 是最安全的选择。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:449
+msgid ""
+"PWM written when the service stops. Keeping the fan at full speed avoids "
+"losing cooling after an unexpected exit."
+msgstr "服务停止时写入的 PWM。保持风扇全速可避免服务意外退出后失去散热。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:380
+msgid "Polling interval"
+msgstr "轮询间隔"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:406
+msgid ""
+"Preferred hwmon name when PWM output is automatic. The pwmfan driver is "
+"preferred by default."
+msgstr "自动选择 PWM 输出时优先使用的 hwmon 名称，默认优先选择 pwmfan 驱动。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:395
+msgid ""
+"Preferred thermal zone type when temperature input is automatic, for example "
+"cpu_top_thermal. Leave as \"auto\" unless several sensors are available."
+msgstr ""
+"自动选择温度输入时优先使用的 thermal zone 类型，例如 cpu_top_thermal。除非存"
+"在多个传感器，否则保持 \"auto\"。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:338
+msgid "Run the controller and apply this temperature curve."
+msgstr "运行风扇控制器并应用此温控曲线。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:246
+msgid "Running"
+msgstr "运行中"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:244
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:296
+msgid "Runtime Status"
+msgstr "运行状态"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:332
+msgid "Safety"
+msgstr "安全"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:439
+msgid "Sensor failure PWM"
+msgstr "传感器故障 PWM"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:445
+msgid "Service exit PWM"
+msgstr "服务退出 PWM"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:326
+msgid "Settings"
+msgstr "设置"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:422
+msgid "Start kick PWM"
+msgstr "启动助推 PWM"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:435
+msgid "Start kick PWM must be non-zero when a kick duration is configured."
+msgstr "配置启动助推时长时，启动助推 PWM 不能为零。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:428
+msgid "Start kick duration"
+msgstr "启动助推时长"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:340
+msgid "Start temperature"
+msgstr "启动温度"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:357
+msgid "Stop hysteresis"
+msgstr "停转回差"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:246
+msgid "Stopped"
+msgstr "已停止"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:235
+msgid "Temperature"
+msgstr "温度"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:328
+msgid "Temperature Curve"
+msgstr "温控曲线"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:414
+msgid "Temperature divisor"
+msgstr "温度除数"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:254
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:386
+msgid "Temperature input"
+msgstr "温度输入"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:344
+msgid ""
+"The fan remains off below this temperature and starts at the minimum running "
+"PWM when it is reached. Unit: °C."
+msgstr ""
+"低于此温度时风扇保持停止；达到此温度时，以最低运行 PWM 启动。单位为 °C。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:392
+msgid "Thermal zone type"
+msgstr "温度区域类型"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:390
+msgid ""
+"Use \"auto\" to select a CPU or SoC thermal sensor, or enter an absolute "
+"thermal zone or hwmon tempN_input path."
+msgstr ""
+"使用 \"auto\" 自动选择 CPU 或 SoC 温度传感器，也可输入 thermal zone 或 hwmon "
+"tempN_input 的绝对路径。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:401
+msgid ""
+"Use \"auto\" to select a writable hwmon pwmN output, or enter its absolute "
+"path. cooling_device cur_state is not a PWM output."
+msgstr ""
+"使用 \"auto\" 自动选择可写的 hwmon pwmN 输出，也可输入其绝对路径。"
+"cooling_device cur_state 不是 PWM 输出。"
+
+#: applications/luci-app-fancontrol/htdocs/luci-static/resources/view/fancontrol.js:454
+msgid ""
+"Write temperature, PWM and RPM values to the system log at every polling "
+"interval."
+msgstr "每次轮询时将温度、PWM 和 RPM 数值写入系统日志。"

--- a/applications/luci-app-fancontrol/root/usr/share/luci/menu.d/luci-app-fancontrol.json
+++ b/applications/luci-app-fancontrol/root/usr/share/luci/menu.d/luci-app-fancontrol.json
@@ -1,0 +1,13 @@
+{
+	"admin/services/fancontrol": {
+		"title": "Fan Control",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "fancontrol"
+		},
+		"depends": {
+			"acl": [ "luci-app-fancontrol" ]
+		}
+	}
+}

--- a/applications/luci-app-fancontrol/root/usr/share/rpcd/acl.d/luci-app-fancontrol.json
+++ b/applications/luci-app-fancontrol/root/usr/share/rpcd/acl.d/luci-app-fancontrol.json
@@ -1,0 +1,17 @@
+{
+	"luci-app-fancontrol": {
+		"description": "Grant access to Fan Control",
+		"read": {
+			"uci": [ "fancontrol" ],
+			"ubus": {
+				"service": [ "list" ]
+			},
+			"file": {
+				"/var/run/fancontrol.status": [ "read" ]
+			}
+		},
+		"write": {
+			"uci": [ "fancontrol" ]
+		}
+	}
+}


### PR DESCRIPTION
## Pull request details

### Description

Add a LuCI interface for the fancontrol service with automatic hardware
selection, temperature curve and safety settings, live service status, and
runtime temperature, PWM, and fan-speed charts.

The rpcd ACL is restricted to the fancontrol UCI configuration, service
status, and the read-only runtime status file. A complete Simplified Chinese
translation is included in po/zh_Hans, with the generated POT template retained
for the Weblate workflow.

Depends on immortalwrt/packages#1974. This PR is a draft until that package
dependency is merged.

### Maintainer

@JiaY-shi

---

## Tested on

**OpenWrt version:** Previously validated in a custom ImmortalWrt master build
**LuCI version:** master
**Web browser(s):** Not recorded for this repository split

---

## Checklist

- [x] Includes its dependency on immortalwrt/packages#1974.